### PR TITLE
feat: pre release of versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: install
 	npx tsc --emitDeclarationOnly --outDir dist
 
 run:
-	npx ts-node src/main.ts tag --repo-dir=.
+	npx ts-node src/main.ts tag --repo-dir=. --prerelease
 
 lint:
 	npx eslint . --ext .ts

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: install
 	npx tsc --emitDeclarationOnly --outDir dist
 
 run:
-	npx ts-node src/main.ts release --repo-dir=.
+	npx ts-node src/main.ts tag --repo-dir=.
 
 lint:
 	npx eslint . --ext .ts

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ npx monotag tag --path=libs/my-lib1
 
 npx monotag tag --path=services/my-service2
 # will return "my-service2/1.3.0" as tag along with "Features: -new interface to lib2; Fixes: -bug fix according to #43"
-# (if latest tag was my-service2/1.2.9, for example)
+# (if latest tag was my-service2/1.2.9 and a minor change was detected, for example)
+
+npx monotag tag --path=services/my-service2 --prerelease=true
+# will return "my-service2/1.3.0-beta.0" as tag along with "Features: -new interface to lib2; Fixes: -bug fix according to #43"
+# (if latest tag was my-service2/1.2.9 and a minor change was detected, for example)
 
 ```
 
@@ -93,17 +97,20 @@ The library exposes its ts types, so you can use VSCode for auto completing and 
 
 ### CLI example
 
-- 'monotag tag'
+- `monotag tag`
   - Will use current dir as repo and tag prefix name, try to find the latest tag in this repo with this prefix, look for changes since the last tag to HEAD and output a newer version according to conventional commit changes
   
-- 'monotag notes --from-ref=HEAD~3 --to-ref=HEAD --path services/myservice'
+- `monotag notes --from-ref=HEAD~3 --to-ref=HEAD --path services/myservice`
   - Generate release notes according to changes made in the last 3 commits for changes in dir services/myservice of the repo
 
-- 'monotag tag --path services/myservice'
+- `monotag tag --path services/myservice`
   - Generate tag "myservice/1.3.0" if previous tag was "myservice/1.2.8" and one commit with comment "feat: adding something new" is found between commits from the latest tag and HEAD
 
-- 'monotag tag --path services/myservice --separator=/v'
+- `monotag tag --path services/myservice --separator=/v`
   - Generate tag "myservice/v1.3.0" if previous tag was "myservice/v1.2.8" and one commit with comment "feat: adding something new" is found between commits from the latest tag and HEAD
+
+- `monotag tag --path services/myservice --prerelease`
+  - Generate tag "myservice/1.3.0-beta.0" if previous tag was "myservice/1.2.8" and one commit with comment "feat: adding something new" is found between commits from the latest tag and HEAD
 
 ### Github actions workflow
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/conventional-commits-parser": "^3.0.3",
     "@types/jest": "^29.4.0",
     "@types/yargs": "^17.0.22",
+    "@types/semver": "^7.5.8",
     "esbuild": "^0.17.7",
     "esbuild-jest": "^0.5.0",
     "eslint": "^8.34.0",
@@ -50,6 +51,7 @@
   },
   "dependencies": {
     "conventional-commits-parser": "^3.2.4",
+    "semver": "^7.7.0",
     "yargs": "^17.6.2"
   }
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -99,6 +99,25 @@ describe('when using cli', () => {
     expect(stdout).toEqual('345.2123.143');
     expect(exitCode).toBe(0);
 
+    // get next tag
+    stdout = '';
+    exitCode = await run(['', '', 'tag', `--repo-dir=${repoDir}`]);
+    expect(stdout).toEqual('346.0.0');
+    expect(exitCode).toBe(0);
+
+    // get next tag as prerelease
+    stdout = '';
+    exitCode = await run([
+      '',
+      '',
+      'tag',
+      `--repo-dir=${repoDir}`,
+      '--prerelease=true',
+      '--pre-identifier=alpha',
+    ]);
+    expect(stdout).toEqual('346.0.0-alpha.0');
+    expect(exitCode).toBe(0);
+
     // generate tag in git repo and tag it
     stdout = '';
     exitCode = await run(['', '', 'tag-git', `--repo-dir=${repoDir}`, '--fromRef=HEAD~3']);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,20 +58,20 @@ const run = async (processArgs: string[]): Promise<number> => {
 
   const showNotes = defaultValueBoolean(args2['show-notes'], false);
 
-  const changelogFile = defaultValueString(args2['changelog-file'], undefined);
-  const versionFile = defaultValueString(args2['version-file'], undefined);
-  const releasetagFile = defaultValueString(args2['releasetag-file'], undefined);
+  // const changelogFile = defaultValueString(args2['changelog-file'], undefined);
+  // const versionFile = defaultValueString(args2['version-file'], undefined);
+  // const releasetagFile = defaultValueString(args2['releasetag-file'], undefined);
 
   const args = expandDefaults(args2);
 
-  const args3 = {
-    changelogFile,
-    releasetagFile,
-    versionFile,
-    ...args,
-  };
+  // const args3 = {
+  //   changelogFile,
+  //   releasetagFile,
+  //   versionFile,
+  //   ...args,
+  // };
 
-  return execAction(action, args3, showNotes, yargs2);
+  return execAction(action, args, showNotes, yargs2);
 };
 
 const execAction = async (
@@ -119,6 +119,7 @@ const execAction = async (
   // TAG* ACTIONS
   if (action.startsWith('tag')) {
     // calculate and show tag
+    // console.log(`>>> TAG ${opts.preRelease}`);
     const nt = await nextTag(opts);
     if (nt == null) {
       console.log('No changes detected and no previous tag found');
@@ -199,7 +200,9 @@ const expandDefaults = (args: any): NextTagOptions => {
     onlyConvCommit: defaultValueBoolean(args['conv-commit'], true),
     verbose,
   };
+
   let tagPrefix = args.prefix;
+
   // default tag prefix is relative to path inside repo
   if (tagPrefix === 'auto') {
     tagPrefix = lastPathPart(basicOpts.path);
@@ -207,13 +210,17 @@ const expandDefaults = (args: any): NextTagOptions => {
       tagPrefix += args.separator;
     }
   }
-  return <NextTagOptions>{
+
+  return {
     ...basicOpts,
-    ...{
-      tagPrefix,
-      tagSuffix: args.suffix,
-      semverLevel: <number>args['semver-level'],
-    },
+    tagPrefix,
+    tagSuffix: args.suffix,
+    semverLevel: <number>args['semver-level'],
+    preRelease: defaultValueBoolean(args.prerelease, false),
+    preReleaseIdentifier: defaultValueString(args['pre-identifier'], undefined),
+    versionFile: defaultValueString(args['version-file'], undefined),
+    changelogFile: defaultValueString(args['changelog-file'], undefined),
+    releasetagFile: defaultValueString(args['releasetag-file'], undefined),
   };
 };
 
@@ -285,15 +292,15 @@ const addOptions = (y: Argv, notes?: boolean, release?: boolean): any => {
       default: '',
     })
     .option('prerelease', {
-      alias: 'p',
+      alias: 'pre',
       type: 'boolean',
-      describe: 'Create tags as pre-release versions. E.g.: 2.1.0-beta',
+      describe: 'Create tags as pre-release versions. E.g.: 2.1.0-beta.0',
       default: false,
     })
     .option('pre-identifier', {
       alias: 'pid',
       type: 'string',
-      describe: 'Pre-release identifier',
+      describe: 'Pre-release identifier. E.g.: beta',
       default: 'beta',
     });
 

--- a/src/tag.test.ts
+++ b/src/tag.test.ts
@@ -215,4 +215,29 @@ describe('when generating next tag with notes', () => {
     expect(clogs[3].message.includes('13')).toBeTruthy();
     expect(clogs[4].message.includes('14')).toBeTruthy();
   });
+
+  it('should create pre-release correctly', async () => {
+    const nt = await nextTag({
+      repoDir,
+      fromRef: 'auto',
+      toRef: 'HEAD',
+      path: 'prefix1',
+      tagPrefix: 'prefix1/',
+      preRelease: true,
+    });
+    if (!nt) throw new Error('Shouldnt be null');
+    expect(nt.tagName).toBe('prefix1/3.5.0-beta.0');
+  });
+  it('should create release correctly', async () => {
+    const nt = await nextTag({
+      repoDir,
+      fromRef: 'auto',
+      toRef: 'HEAD',
+      path: 'prefix1',
+      tagPrefix: 'prefix1/',
+      preRelease: false,
+    });
+    if (!nt) throw new Error('Shouldnt be null');
+    expect(nt.tagName).toBe('prefix1/3.5.0');
+  });
 });

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -75,11 +75,15 @@ const nextTag = async (opts: NextTagOptions): Promise<TagNotes | null> => {
   const commitsSummary = summarizeCommits(commits);
 
   const currentTag = latestTag ?? `${opts.tagPrefix}0.0.0`;
-  const tagName = incrementTag(
-    currentTag,
-    opts.semverLevel ?? commitsSummary.level,
-    opts.tagSuffix,
-  );
+  const tagName = incrementTag({
+    fullTagName: currentTag,
+    type: opts.semverLevel ?? commitsSummary.level,
+    tagSuffix: opts.tagSuffix,
+    minVersion: opts.minVersion,
+    maxVersion: opts.maxVersion,
+    preRelease: opts.preRelease,
+    preReleaseIdentifier: opts.preReleaseIdentifier,
+  });
 
   const versionDate = getDateFromCommit(commits[0].date);
 

--- a/src/types/NextTagOptions.ts
+++ b/src/types/NextTagOptions.ts
@@ -5,10 +5,59 @@ import { SemverLevel } from './SemverLevel';
  * Options for analyzing and generating a new tag
  */
 export type NextTagOptions = BasicOptions & {
-  // Tag prefix to look for latest tag and for generating the tag
+  /**
+   * Tag prefix to look for latest tag and for generating the tag
+   */
   tagPrefix: string;
-  // Tag suffix to add to generated tag
+  /**
+   * Tag suffix to add to generated tag
+   */
   tagSuffix?: string;
-  // Which level to increment the version. If null, will be automatic, based on commit messages
+  /**
+   * Which level to increment the version. If null, will be automatic, based on commit messages
+   */
   semverLevel?: SemverLevel;
+  /**
+   * Minimum version for the generated tag.
+   * If the naturally incremented version is lower, this value will be used
+   * @default no limit
+   */
+  minVersion?: string;
+  /**
+   * Maximum version for the generated tag.
+   * If the generated version is higher than this, the operation will fail
+   * @default no limit
+   */
+  maxVersion?: string;
+  /**
+   * If the generated version is a pre-release
+   * This will add a pre-release identifier to the version. E.g.: 1.0.0-beta
+   * This will automatically create a pre-release version depending on the semverLevel
+   * identified by commit message analysis based on conventional commits.
+   * For example, if the commits contain a breaking change, the version will be a major pre-release.
+   * So if it was 1.2.2, it will be 2.0.0-beta. If it was 3.2.1, it will be 4.0.0-beta.
+   * The same applies for minor and patch levels.
+   * @default false
+   */
+  preRelease?: boolean;
+  /**
+   * Pre-release identifier
+   * @default 'beta'
+   */
+  preReleaseIdentifier?: string;
+  /**
+   * File that will be written with the release tag
+   * Won't be written if not provided
+   */
+  releasetagFile?: string;
+  /**
+   * File that will be written with the version
+   * Won't be written if not provided
+   */
+  versionFile?: string;
+  /**
+   * File that will be written with the changelog
+   * Won't be written if not provided
+   */
+  changelogFile?: string;
 };

--- a/src/types/ReleaseOptions.ts
+++ b/src/types/ReleaseOptions.ts
@@ -1,7 +1,0 @@
-import { NextTagOptions } from './NextTagOptions';
-
-export type ReleaseOptions = NextTagOptions & {
-  releasetagFile?: string;
-  versionFile?: string;
-  changelogFile?: string;
-};

--- a/src/types/SemverLevel.ts
+++ b/src/types/SemverLevel.ts
@@ -2,4 +2,5 @@ export enum SemverLevel {
   MAJOR = 1,
   MINOR = 2,
   PATCH = 3,
+  NONE = 4,
 }

--- a/src/utils/getVersionFromTag.ts
+++ b/src/utils/getVersionFromTag.ts
@@ -1,8 +1,17 @@
-export const getVersionFromTag = (tagName: string, tagPrefix: string): string => {
-  let version = tagName.replace(tagPrefix, '');
-  const versionMatch = /(\d+\.\d+\.\d+.*)/.exec(tagName);
+export const getVersionFromTag = (
+  tagName: string,
+  tagPrefix?: string,
+  tagSuffix?: string,
+): string => {
+  // remove the tagPrefix only if appearing in the beginning of the tagName string using regex
+  const versionPart = tagName
+    .replace(new RegExp(`^${tagPrefix ?? ''}`), '')
+    .replace(new RegExp(`${tagSuffix ?? ''}$`), '');
+
+  // let version = tagName.replace(tagPrefix, '').replace(tagSuffix, '');
+  const versionMatch = /(\d+\.\d+\.\d+.*)/.exec(versionPart);
   if (versionMatch) {
-    version = versionMatch[0];
+    return versionMatch[0];
   }
-  return version;
+  return versionPart;
 };

--- a/src/utils/incrementTag.test.ts
+++ b/src/utils/incrementTag.test.ts
@@ -4,46 +4,180 @@ import { incrementTag } from './incrementTag';
 
 describe('when using tag incrementer', () => {
   it('should increment major and zero other parts', async () => {
-    let rr = incrementTag('my-service-prefix/0.1.0-beta+build999', SemverLevel.MAJOR);
+    let rr = incrementTag({
+      fullTagName: 'my-service-prefix/0.1.0-beta+build999',
+      type: SemverLevel.MAJOR,
+    });
     expect(rr).toBe('my-service-prefix/1.0.0');
-    rr = incrementTag('my-service-prefix/14.22.5-beta+build999', SemverLevel.MAJOR, '-beta');
+    rr = incrementTag({
+      fullTagName: 'my-service-prefix/14.22.5-beta+build999',
+      type: SemverLevel.MAJOR,
+      tagSuffix: '-beta',
+    });
     expect(rr).toBe('my-service-prefix/15.0.0-beta');
-    rr = incrementTag('24.22.5-beta+build999', SemverLevel.MAJOR, '');
+    rr = incrementTag({
+      fullTagName: '24.22.5-beta+build999',
+      type: SemverLevel.MAJOR,
+      tagSuffix: '',
+    });
     expect(rr).toBe('25.0.0');
   });
 
   it('should increment major and zero other parts -', async () => {
-    let rr = incrementTag('my-service-prefix-0.1.0-beta+build999', SemverLevel.MAJOR);
+    let rr = incrementTag({
+      fullTagName: 'my-service-prefix-0.1.0-beta+build999',
+      type: SemverLevel.MAJOR,
+    });
     expect(rr).toBe('my-service-prefix-1.0.0');
-    rr = incrementTag('my-service-prefix-14.22.5-beta+build999', SemverLevel.MAJOR, '-beta');
+    rr = incrementTag({
+      fullTagName: 'my-service-prefix-14.22.5-beta+build999',
+      type: SemverLevel.MAJOR,
+      tagSuffix: '-beta',
+    });
     expect(rr).toBe('my-service-prefix-15.0.0-beta');
-    rr = incrementTag('24.22.5-beta+build999', SemverLevel.MAJOR, '');
+    rr = incrementTag({
+      fullTagName: '24.22.5-beta+build999',
+      type: SemverLevel.MAJOR,
+      tagSuffix: '',
+    });
     expect(rr).toBe('25.0.0');
   });
 
   it('should increment minor and zero other parts', async () => {
-    let rr = incrementTag('my-service-prefix/0.1.0-beta+build999', SemverLevel.MINOR);
-    expect(rr).toBe('my-service-prefix/0.2.0');
-    rr = incrementTag('my-service-prefix/14.22.5-beta+build999', SemverLevel.MINOR, '-beta');
+    let rr = incrementTag({
+      fullTagName: 'my-service-prefix/0.1.0-beta+build999',
+      type: SemverLevel.MINOR,
+    });
+    expect(rr).toBe('my-service-prefix/0.1.0');
+    rr = incrementTag({
+      fullTagName: 'my-service-prefix/14.22.5-beta+build999',
+      type: SemverLevel.MINOR,
+      tagSuffix: '-beta',
+    });
     expect(rr).toBe('my-service-prefix/14.23.0-beta');
-    rr = incrementTag('24.22.5-beta+build999', SemverLevel.MINOR, '');
+    rr = incrementTag({
+      fullTagName: '24.22.5-beta+build999',
+      type: SemverLevel.MINOR,
+      tagSuffix: '',
+    });
     expect(rr).toBe('24.23.0');
   });
 
   it('should increment minor and zero other parts', async () => {
-    let rr = incrementTag('my-service-prefix/0.1.0-beta+build999', SemverLevel.PATCH);
-    expect(rr).toBe('my-service-prefix/0.1.1');
-    rr = incrementTag('my-service-prefix/14.22.5-beta+build999', SemverLevel.PATCH, '-beta');
-    expect(rr).toBe('my-service-prefix/14.22.6-beta');
-    rr = incrementTag('24.22.5-beta+build999', SemverLevel.PATCH, '');
-    expect(rr).toBe('24.22.6');
+    let rr = incrementTag({
+      fullTagName: 'my-service-prefix/0.1.0-beta+build999',
+      type: SemverLevel.PATCH,
+    });
+    expect(rr).toBe('my-service-prefix/0.1.0');
+    rr = incrementTag({
+      fullTagName: 'my-service-prefix/14.22.5-beta+build999',
+      type: SemverLevel.PATCH,
+      tagSuffix: '-beta',
+    });
+    expect(rr).toBe('my-service-prefix/14.22.5-beta');
+    rr = incrementTag({ fullTagName: '24.22.5-beta+build999', type: SemverLevel.PATCH });
+    expect(rr).toBe('24.22.5');
   });
   it('should increment minor and zero other parts -', async () => {
-    let rr = incrementTag('my-service-prefix-0.1.0-beta+build999', SemverLevel.PATCH);
-    expect(rr).toBe('my-service-prefix-0.1.1');
-    rr = incrementTag('my-service-prefix-14.22.5-beta+build999', SemverLevel.PATCH, '-beta');
-    expect(rr).toBe('my-service-prefix-14.22.6-beta');
-    rr = incrementTag('24.22.5-beta+build999', SemverLevel.PATCH, '');
-    expect(rr).toBe('24.22.6');
+    let rr = incrementTag({
+      fullTagName: 'my-service-prefix-0.1.0-beta+build999',
+      type: SemverLevel.PATCH,
+    });
+    expect(rr).toBe('my-service-prefix-0.1.0');
+    rr = incrementTag({
+      fullTagName: 'my-service-prefix-14.22.5-beta+build999',
+      type: SemverLevel.PATCH,
+      tagSuffix: '-win64',
+    });
+    expect(rr).toBe('my-service-prefix-14.22.5-win64');
+    rr = incrementTag({
+      fullTagName: '24.22.5-beta+build999',
+      type: SemverLevel.PATCH,
+      tagSuffix: '',
+    });
+    expect(rr).toBe('24.22.5');
+  });
+  it('should respect minVersion when incrementing', async () => {
+    let rr = incrementTag({
+      fullTagName: 'my-service-prefix/0.1.0-beta+build999',
+      type: SemverLevel.MAJOR,
+      tagSuffix: '',
+      minVersion: '2.0.0',
+    });
+    expect(rr).toBe('my-service-prefix/2.0.0');
+    rr = incrementTag({
+      fullTagName: '24.22.5-beta+build999',
+      type: SemverLevel.PATCH,
+      minVersion: '24.22.10',
+    });
+    expect(rr).toBe('24.22.10');
+  });
+
+  it('should throw error if incremented version exceeds maxVersion', async () => {
+    const rr = incrementTag({
+      fullTagName: 'my-service-prefix/14.22.5-abraca+build999',
+      type: SemverLevel.MINOR,
+      tagSuffix: '-beta',
+      maxVersion: '14.23.1',
+    });
+    expect(rr).toBe('my-service-prefix/14.23.0-beta');
+    expect(() => {
+      incrementTag({
+        fullTagName: 'my-service-prefix/0.1.0-beta+build999',
+        type: SemverLevel.MAJOR,
+        maxVersion: '0.5.0',
+      });
+    }).toThrow('Generated tag version 1.0.0 is greater than 0.5.0');
+    expect(() => {
+      incrementTag({
+        fullTagName: 'my-service-prefix/14.22.5-beta+build999',
+        type: SemverLevel.MINOR,
+        tagSuffix: '-beta',
+        maxVersion: '14.22.6',
+      });
+    }).toThrow('Generated tag version 14.23.0 is greater than 14.22.6');
+    expect(() => {
+      incrementTag({
+        fullTagName: '24.22.5-beta+build999',
+        type: SemverLevel.PATCH,
+        maxVersion: '24.22.4',
+      });
+    }).toThrow('Generated tag version 24.22.5 is greater than 24.22.4');
+  });
+  it('should create pre-release versions', async () => {
+    let rr = incrementTag({
+      fullTagName: 'my-service-prefix/0.1.0-beta+build999',
+      type: SemverLevel.PATCH,
+      preRelease: true,
+    });
+    expect(rr).toBe('my-service-prefix/0.1.1-beta.0');
+    rr = incrementTag({
+      fullTagName: 'my-service-prefix/14.22.5',
+      type: SemverLevel.MINOR,
+      preRelease: true,
+    });
+    expect(rr).toBe('my-service-prefix/14.23.0-beta.0');
+    rr = incrementTag({
+      fullTagName: 'my-service-prefix/0.1.5',
+      type: SemverLevel.MAJOR,
+      preRelease: true,
+    });
+    expect(rr).toBe('my-service-prefix/1.0.0-beta.0');
+    rr = incrementTag({
+      fullTagName: 'my-service-prefix/0.1.5-beta',
+      type: SemverLevel.NONE,
+      preRelease: false,
+    });
+    expect(rr).toBe('my-service-prefix/0.1.5');
+    rr = incrementTag({
+      fullTagName: 'my-service-prefix/0.1.5-beta',
+      type: SemverLevel.NONE,
+      preRelease: false,
+    });
+    expect(rr).toBe('my-service-prefix/0.1.5');
+    rr = incrementTag({ fullTagName: '24.22.5-beta.0', type: SemverLevel.NONE, preRelease: true });
+    expect(rr).toBe('24.22.5-beta.1');
+    rr = incrementTag({ fullTagName: '24.22.5-beta.0', type: SemverLevel.PATCH, preRelease: true });
+    expect(rr).toBe('24.22.6-beta.0');
   });
 });

--- a/src/utils/incrementTag.ts
+++ b/src/utils/incrementTag.ts
@@ -1,37 +1,97 @@
+import semver, { ReleaseType } from 'semver';
+
 import { SemverLevel } from '../types/SemverLevel';
 
 import { tagParts } from './tagParts';
+import { getVersionFromTag } from './getVersionFromTag';
 
 /**
  * Increment tag in certain semantic levels
  * @param fullTagName Full tag name with prefix, version and suffix, if exists.
  *                      Ex.: myservice/15.1.3-beta
  * @param type One of MAJOR, MINOR or PATCH (SemverLevel enum)
- * @param tagSuffix String to be added to the resulting tag name
+ * @param tagPrefix Prefix to be added to the generated version. e.g.: myservice/
+ * @param tagSuffix String to be added to the resulting tag name. e.g.: +win64
+ * @param minVersion Minimum version to be returned. If the generated version is lower,
+ * this value will be used
+ * @param maxVersion Maximum version to be returned. If the generated version is higher,
+ * an error will be thrown
+ * @param preRelease If true, the version will be pre-released. e.g: 1.0.0-beta.1
+ * @param preReleaseIdentifier Identifier for pre-release. e.g: beta
  * @returns Incremented tag version with prefix, new version and suffix.
  *          Ex.: myservice/16.0.0
  */
-export const incrementTag = (
-  fullTagName: string,
-  type: SemverLevel,
-  tagSuffix: string = '',
-): string => {
-  const tparts = tagParts(fullTagName);
+export const incrementTag = (args: {
+  fullTagName: string;
+  type: SemverLevel;
+  tagPrefix?: string;
+  tagSuffix?: string;
+  minVersion?: string;
+  maxVersion?: string;
+  preRelease?: boolean;
+  preReleaseIdentifier?: string;
+}): string => {
+  const tagSuffix = args.tagSuffix ? args.tagSuffix : '';
+  const tparts = tagParts(args.fullTagName);
   if (!tparts) {
-    throw new Error(`Tag '${fullTagName}' is not valid`);
+    throw new Error(`Tag '${args.fullTagName}' is not valid`);
   }
-  const newVersion = [parseInt(tparts[4], 10), parseInt(tparts[5], 10), parseInt(tparts[6], 10)];
+  const versionFromTag = getVersionFromTag(args.fullTagName, args.tagPrefix, args.tagSuffix);
+  const curVersion = semver.coerce(versionFromTag, { loose: true, includePrerelease: true });
+  if (!curVersion) {
+    throw new Error(`Version could not be extracted from tag. tag=${args.fullTagName}`);
+  }
+
+  // define the increment type
+  const incType = getIncType(args.type, args.preRelease ?? false);
+
+  // perform release because this is not an increment
+  // (just remove pre-release suffix from version. e.g: 1.0.0-beta.1 -> 1.0.0)
+  // if (!incType) {
+  //   return `${tparts[2] ? tparts[2] : ''}${curVersion.major}.${curVersion.minor}.${
+  //     curVersion.patch
+  //   }${tagSuffix}`;
+  // }
+
+  // increment version
+  const incVersion = curVersion.inc(incType, args.preReleaseIdentifier ?? 'beta');
+
+  // check min
+  const minVersionSemver = semver.coerce(args.minVersion);
+  if (minVersionSemver && incVersion.compare(minVersionSemver) === -1) {
+    return `${tparts[2] ? tparts[2] : ''}${minVersionSemver}${tagSuffix}`;
+  }
+
+  // check max
+  const maxVersionSemver = semver.coerce(args.maxVersion);
+  if (maxVersionSemver && incVersion.compare(maxVersionSemver) === 1) {
+    throw new Error(`Generated tag version ${incVersion} is greater than ${args.maxVersion}`);
+  }
+
+  return `${tparts[2] ? tparts[2] : ''}${incVersion}${tagSuffix}`;
+};
+
+const getIncType = (type: SemverLevel, preRelease: boolean): ReleaseType => {
   if (type === SemverLevel.MAJOR) {
-    newVersion[0] += 1;
-    newVersion[1] = 0;
-    newVersion[2] = 0;
+    if (preRelease) {
+      return 'premajor';
+    }
+    return 'major';
   } else if (type === SemverLevel.MINOR) {
-    newVersion[1] += 1;
-    newVersion[2] = 0;
-  } else {
-    newVersion[2] += 1;
+    if (preRelease) {
+      return 'preminor';
+    }
+    return 'minor';
+  } else if (type === SemverLevel.PATCH) {
+    if (preRelease) {
+      return 'prepatch';
+    }
+    return 'patch';
   }
-  return `${tparts[2] ? tparts[2] : ''}${newVersion[0]}.${newVersion[1]}.${
-    newVersion[2]
-  }${tagSuffix}`;
+  if (preRelease) {
+    return 'prerelease';
+  }
+
+  // @ts-ignore this type is not on the @type definition, but present on the library
+  return 'release';
 };

--- a/src/utils/incrementTag.ts
+++ b/src/utils/incrementTag.ts
@@ -45,14 +45,6 @@ export const incrementTag = (args: {
   // define the increment type
   const incType = getIncType(args.type, args.preRelease ?? false);
 
-  // perform release because this is not an increment
-  // (just remove pre-release suffix from version. e.g: 1.0.0-beta.1 -> 1.0.0)
-  // if (!incType) {
-  //   return `${tparts[2] ? tparts[2] : ''}${curVersion.major}.${curVersion.minor}.${
-  //     curVersion.patch
-  //   }${tagSuffix}`;
-  // }
-
   // increment version
   const incVersion = curVersion.inc(incType, args.preReleaseIdentifier ?? 'beta');
 

--- a/src/utils/saveResultsToFile.test.ts
+++ b/src/utils/saveResultsToFile.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 
 import { TagNotes } from '../types/TagNotes';
-import { ReleaseOptions } from '../types/ReleaseOptions';
+import { NextTagOptions } from '../types/NextTagOptions';
 
 import { saveResultsToFile } from './saveResultsToFile';
 
@@ -14,11 +14,14 @@ describe('saveResultsToFile', () => {
     changesDetected: 1,
   };
 
-  const releaseOptions: ReleaseOptions = {
+  const releaseOptions: NextTagOptions = {
     repoDir,
     tagPrefix: 'v',
     verbose: true,
     path: '.',
+    versionFile: 'dist/version.txt',
+    changelogFile: 'dist/changelog.md',
+    releasetagFile: 'dist/releasetag.txt',
   };
 
   it('should save version to file', () => {

--- a/src/utils/saveResultsToFile.ts
+++ b/src/utils/saveResultsToFile.ts
@@ -1,38 +1,42 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { ReleaseOptions } from '../types/ReleaseOptions';
 import { TagNotes } from '../types/TagNotes';
+import { NextTagOptions } from '../types/NextTagOptions';
 
 import { getVersionFromTag } from './getVersionFromTag';
 
-export const saveResultsToFile = (nt: TagNotes, opts: ReleaseOptions): void => {
-  // save version to file
-  const versionFile = opts.versionFile ?? 'dist/version.txt';
+export const saveResultsToFile = (nt: TagNotes, opts: NextTagOptions): void => {
   // extract version from tag by matching with version part from tag
-  const version = getVersionFromTag(nt.tagName, opts.tagPrefix);
-  fs.mkdirSync(path.dirname(versionFile), { recursive: true });
-  fs.rmSync(versionFile, { force: true });
-  fs.writeFileSync(versionFile, version, { encoding: 'utf8' });
-  if (opts.verbose) {
-    console.log(`Version saved to file: ${versionFile}`);
+  const version = getVersionFromTag(nt.tagName, opts.tagPrefix, opts.tagSuffix);
+
+  // save version to file
+  if (opts.versionFile) {
+    fs.mkdirSync(path.dirname(opts.versionFile), { recursive: true });
+    fs.rmSync(opts.versionFile, { force: true });
+    fs.writeFileSync(opts.versionFile, version, { encoding: 'utf8' });
+    if (opts.verbose) {
+      console.log(`Version saved to file: ${opts.versionFile}`);
+    }
   }
 
   // save changelog to file
-  const changelogFile = opts.changelogFile ?? 'dist/changelog.md';
-  fs.mkdirSync(path.dirname(changelogFile), { recursive: true });
-  fs.rmSync(changelogFile, { force: true });
-  fs.writeFileSync(changelogFile, nt.releaseNotes, { encoding: 'utf8' });
-  if (opts.verbose) {
-    console.log(`Changelog saved to file: ${changelogFile}`);
+  if (opts.changelogFile) {
+    fs.mkdirSync(path.dirname(opts.changelogFile), { recursive: true });
+    fs.rmSync(opts.changelogFile, { force: true });
+    fs.writeFileSync(opts.changelogFile, nt.releaseNotes, { encoding: 'utf8' });
+    if (opts.verbose) {
+      console.log(`Changelog saved to file: ${opts.changelogFile}`);
+    }
   }
 
   // save releasetag to file
-  const releasetagFile = opts.releasetagFile ?? 'dist/releasetag.txt';
-  fs.mkdirSync(path.dirname(releasetagFile), { recursive: true });
-  fs.rmSync(releasetagFile, { force: true });
-  fs.writeFileSync(releasetagFile, nt.tagName, { encoding: 'utf8' });
-  if (opts.verbose) {
-    console.log(`Release tag saved to file: ${releasetagFile}`);
+  if (opts.releasetagFile) {
+    fs.mkdirSync(path.dirname(opts.releasetagFile), { recursive: true });
+    fs.rmSync(opts.releasetagFile, { force: true });
+    fs.writeFileSync(opts.releasetagFile, nt.tagName, { encoding: 'utf8' });
+    if (opts.verbose) {
+      console.log(`Release tag saved to file: ${opts.releasetagFile}`);
+    }
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,6 +1185,11 @@
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
+"@types/semver@^7.5.8":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz"
@@ -4821,6 +4826,11 @@ semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.7.0:
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.0.tgz#9c6fe61d0c6f9fa9e26575162ee5a9180361b09c"
+  integrity sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==
 
 sentence-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

Add pre-release capability to control and increment pre-release suffixes.

For example, now if you enable pre-release (--prerelease=true), a suffix will be automatically added to the final version. e.g.: 1.0.0-beta.0.

## Breaking changes

None
