### PR TITLE
feat: adding current action to cli; enhancing sorting of versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: install
 	pnpm exec tsc --emitDeclarationOnly --outDir dist
 
 run:
-	npx ts-node src/main.ts tag --repo-dir=. --prerelease
+	npx ts-node src/main.ts current --repo-dir=. --version-file='dist/version.txt' 
 
 lint:
 	pnpm exec eslint ./src --ext .ts
@@ -38,7 +38,7 @@ publish:
 clean:
 	rm -rf node_modules
 
-all: build lint unit-tests
+all: build lint test
 
 install:
 	corepack enable pnpm

--- a/README.md
+++ b/README.md
@@ -98,7 +98,14 @@ The library exposes its ts types, so you can use VSCode for auto completing and 
 ### CLI example
 
 - `monotag tag`
-  - Will use current dir as repo and tag prefix name, try to find the latest tag in this repo with this prefix, look for changes since the last tag to HEAD and output a newer version according to conventional commit changes
+  - Will use current dir as repo and tag prefix name, try to find the latest tag in this repo with this prefix, look for changes since the last tag to HEAD and output a newer version according to conventional commit changes. If
+  there are not changes since the last tag, the latest tag will be returned.
+
+- `monotag tag --version-file=dist/version.txt --notes-file=dist/changelog.md --tag-file=dist/versiontag.txt`
+  - Same as previous, but saves the version part of the tag in version.txt, the full tag name in versiontag.txt and the change notes in changelog.md
+
+- `monotag current`
+  - Will get the latest tag for current path and check if it's the latest possible tag in the repo. It will fail if there are changes in the repo that would lead to the creation of a new tag. If the latest tag is the latest possible (current), then it will be returned.
   
 - `monotag notes --from-ref=HEAD~3 --to-ref=HEAD --path services/myservice`
   - Generate release notes according to changes made in the last 3 commits for changes in dir services/myservice of the repo

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -102,6 +102,12 @@ describe('when using cli', () => {
     expect(stdout).toEqual('345.2123.143');
     expect(exitCode).toBe(0);
 
+    // get current tag
+    stdout = '';
+    exitCode = await run(['', '', 'current', `--repo-dir=${repoDir}`]);
+    expect(stdout).toContain('The latest tag is not up to date');
+    expect(exitCode).toBe(5);
+
     // get next tag
     stdout = '';
     exitCode = await run(['', '', 'tag', `--repo-dir=${repoDir}`]);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -368,22 +368,22 @@ const addOptions = (y: Argv, notes?: boolean, saveToFile?: boolean): any => {
   }
 
   if (saveToFile) {
-    y1.option('releasetag-file', {
+    y1.option('tag-file', {
       alias: 'ft',
       type: 'string',
-      describe: 'File to save the release tag. Defaults to "dist/releasetag.txt"',
+      describe: 'File to save the release tag',
       default: undefined,
     });
     y1.option('version-file', {
       alias: 'fv',
       type: 'string',
-      describe: 'File to save version. Defaults to "dist/version.txt"',
+      describe: 'File to save version',
       default: undefined,
     });
-    y1.option('changelog-file', {
-      alias: 'fc',
+    y1.option('notes-file', {
+      alias: 'fn',
       type: 'string',
-      describe: 'File to save the changelog. Defaults to "dist/changelog.md"',
+      describe: 'File to save the notes with a changelog',
       default: undefined,
     });
   }

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -4,20 +4,20 @@ import { lastTagForPrefix } from './git';
 import { createSampleRepo } from './utils/createSampleRepo';
 
 describe('when using git', () => {
-  const repoDir = './testcases/tagsrepo';
+  const repoDir = './testcases/git-test-repo';
   beforeAll(async () => {
     await createSampleRepo(repoDir);
   });
   it('should get latest tag for prefix1', async () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     console.log = (): void => {};
-    const ltag = await lastTagForPrefix(repoDir, 'prefix1/', true);
+    const ltag = await lastTagForPrefix(repoDir, 'prefix1/', '', true);
     expect(ltag).toBe('prefix1/3.4.5-alpha');
   });
   it('should get latest tag for prefix1 -', async () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     console.log = (): void => {};
-    const ltag = await lastTagForPrefix(repoDir, 'prefix9-', true);
+    const ltag = await lastTagForPrefix(repoDir, 'prefix9-', '', true);
     expect(ltag).toBe('prefix9-1.0.1');
   });
   it('should get latest tag for prefix2', async () => {

--- a/src/tag.test.ts
+++ b/src/tag.test.ts
@@ -52,12 +52,12 @@ describe('when generating next tag with notes', () => {
     if (!nt) throw new Error('Shouldnt be null');
     console.log(nt.releaseNotes);
     expect(nt.tagName).toBe('prefix1/3.5.0');
-    expect(nt.releaseNotes.includes('## Features')).toBeTruthy();
+    expect(nt.releaseNotes?.includes('## Features')).toBeTruthy();
     expect(
-      nt.releaseNotes.includes('updating test1 and test2 files for module prefix1'),
+      nt.releaseNotes?.includes('updating test1 and test2 files for module prefix1'),
     ).toBeTruthy();
-    expect(nt.releaseNotes.includes('### Bug Fixes')).toBeTruthy();
-    expect(nt.releaseNotes.includes('adding test4 for both prefix1 and prefix2')).toBeTruthy();
+    expect(nt.releaseNotes?.includes('### Bug Fixes')).toBeTruthy();
+    expect(nt.releaseNotes?.includes('adding test4 for both prefix1 and prefix2')).toBeTruthy();
   });
   it('should return latest only with different suffix if nothing changed', async () => {
     const nt = await nextTag({
@@ -113,7 +113,7 @@ describe('when generating next tag with notes', () => {
     const day = now.getDate();
     const versionDate = `${year}-${month < 10 ? '0' : ''}${month}-${day < 10 ? '0' : ''}${day}`;
 
-    expect(nt.releaseNotes.trim()).toBe(`## prefix2/21.0.0 (${versionDate})
+    expect(nt.releaseNotes?.trim()).toBe(`## prefix2/21.0.0 (${versionDate})
 
 ### Features
 

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -7,6 +7,7 @@ import { formatReleaseNotes } from './notes';
 import { NextTagOptions } from './types/NextTagOptions';
 import { TagNotes } from './types/TagNotes';
 import { getDateFromCommit } from './utils/getDateFromCommit';
+import { getVersionFromTag } from './utils/getVersionFromTag';
 import { incrementTag } from './utils/incrementTag';
 import { tagParts } from './utils/tagParts';
 
@@ -28,7 +29,7 @@ const nextTag = async (opts: NextTagOptions): Promise<TagNotes | undefined> => {
   }
 
   // current tag
-  const latestTag = await lastTagForPrefix(opts.repoDir, opts.tagPrefix, opts.verbose);
+  const latestTag = await lastTagForPrefix(opts.repoDir, opts.tagPrefix, '', opts.verbose);
 
   if (opts.verbose) {
     console.log(`Using latest tag '${latestTag}' for '${opts.tagPrefix}'`);
@@ -61,13 +62,16 @@ const nextTag = async (opts: NextTagOptions): Promise<TagNotes | undefined> => {
     // nothing changed in the commit range
     const tparts = tagParts(latestTag);
     if (opts.tagSuffix && tparts) {
-      return <TagNotes>{
-        tagName: `${tparts[2] ?? ''}${tparts[3]}${opts.tagSuffix}`,
+      const tagName = `${tparts[2] ?? ''}${tparts[3]}${opts.tagSuffix}`;
+      return {
+        tagName,
+        version: getVersionFromTag(tagName),
         changesDetected: 0,
       };
     }
-    return <TagNotes>{
+    return {
       tagName: latestTag,
+      version: getVersionFromTag(latestTag),
       changesDetected: 0,
     };
   }
@@ -98,8 +102,9 @@ const nextTag = async (opts: NextTagOptions): Promise<TagNotes | undefined> => {
     opts.onlyConvCommit,
   );
 
-  return <TagNotes>{
+  return {
     tagName,
+    version: getVersionFromTag(tagName),
     releaseNotes,
     changesDetected: commits.length,
   };

--- a/src/types/TagNotes.ts
+++ b/src/types/TagNotes.ts
@@ -1,5 +1,6 @@
 export type TagNotes = {
   tagName: string;
-  releaseNotes: string;
+  version: string;
+  releaseNotes?: string;
   changesDetected: number;
 };

--- a/src/utils/saveResultsToFile.test.ts
+++ b/src/utils/saveResultsToFile.test.ts
@@ -10,6 +10,7 @@ describe('saveResultsToFile', () => {
 
   const tagNotes: TagNotes = {
     tagName: 'v1.0.0',
+    version: '1.0.0',
     releaseNotes: 'Initial release',
     changesDetected: 1,
   };

--- a/src/utils/saveResultsToFile.ts
+++ b/src/utils/saveResultsToFile.ts
@@ -23,6 +23,7 @@ export const saveResultsToFile = (nt: TagNotes, opts: NextTagOptions): void => {
 
   // save changelog to file
   if (opts.changelogFile) {
+    if (!nt.releaseNotes) throw new Error('Release notes are required');
     fs.mkdirSync(path.dirname(opts.changelogFile), { recursive: true });
     fs.rmSync(opts.changelogFile, { force: true });
     fs.writeFileSync(opts.changelogFile, nt.releaseNotes, { encoding: 'utf8' });


### PR DESCRIPTION
## Summary

Adding the "current" action to cli that will fetch the latest tag for prefix, try to create a next tag and check if they match. If they don't match it means that there are commits in the repo that would create a new tag, meaning that the tags are not up-to-date (more tags could be created).

## Breaking changes

There is a fix on the sorting that might create some changes for pre-release situations, but semantically it's correct.
