### PR TITLE
feat: min and max version limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ The library exposes its ts types, so you can use VSCode for auto completing and 
 - `monotag tag --changelog-file=docs/changelog.md`
   - Calculates next tag and add the release notes of the version to the existing docs/changelog.md file by appending the contents of the version notes to the top of the file so that this file will contain a history of versions.
 
+- `monotag tag --min-version=2.0.0 --max-version=2.999.999`
+  - Limit the generated versions to 1.x. If the calculated version is lower than 2.x, force to 2.0.0. If the generated version is higher than 2.x (due to a major change), fail. Useful when controlling versioning on specific major release branches (e.g.: branch 2.x).
+
 - `monotag current`
   - Will get the latest tag for current path and check if it's the latest possible tag in the repo. It will fail if there are changes in the repo that would lead to the creation of a new tag. If the latest tag is the latest possible (current), then it will be returned.
   

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -78,6 +78,19 @@ describe('when using cli', () => {
     expect(stdout).toMatch('user-ui: 9 prefix1');
     expect(stdout).toMatch('### Info');
 
+    // min version
+    stdout = '';
+    exitCode = await run(['', '', 'tag', `--repo-dir=${repoDir}`, '--min-version=400.1']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch('400.1.0');
+
+    // max version (should fail if more than max version)
+    stdout = '';
+    const mvc = async (): Promise<void> => {
+      await run(['', '', 'tag', `--repo-dir=${repoDir}`, '--max-version=1']);
+    };
+    await expect(mvc).rejects.toThrow('Generated tag version 346.0.0 is greater than 1');
+
     stdout = '';
     exitCode = await run([
       '',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -268,6 +268,8 @@ const expandDefaults = (args: any): NextTagOptions => {
     notesFile: defaultValueString(args['notes-file'], undefined),
     tagFile: defaultValueString(args['tag-file'], undefined),
     changelogFile: defaultValueString(args['changelog-file'], undefined),
+    minVersion: defaultValueString(args['min-version'], undefined),
+    maxVersion: defaultValueString(args['max-version'], undefined),
   };
 };
 
@@ -376,6 +378,20 @@ const addOptions = (y: Argv, saveToFile?: boolean): any => {
       type: 'string',
       describe:
         'Changelog file that will be appended with new version/release notes. Disabled for prerelease versions',
+      default: undefined,
+    });
+    y1.option('min-version', {
+      alias: 'lv',
+      type: 'string',
+      describe:
+        'Minimum version to be considered when calculating next version. If calculated version is lower, this value will be used instead',
+      default: undefined,
+    });
+    y1.option('max-version', {
+      alias: 'uv',
+      type: 'string',
+      describe:
+        'Maximum version to be considered when calculating next version. If calculated version is higher, the process will fail',
       default: undefined,
     });
   }


### PR DESCRIPTION
## Summary

Adds arguments --min-version and --max-version to control the minimum version to be automatically generated and to limit the max version. Useful while controlling generated version per major release branch (e.g.: 1.x branch), or to start a '1.0.0' after incubating for a while (e.g.: 0.0.1 versions).

## Breaking changes

None

