### PR TITLE
feat: notes generation for existing tags

### DIFF
--- a/.github/workflows/create-next-tag-pre.yml
+++ b/.github/workflows/create-next-tag-pre.yml
@@ -1,0 +1,23 @@
+name: create-next-tag
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # this is needed if you want the tag push to trigger another workflow
+          # create a personal token and set a secret with name GH_PERSONAL_TOKEN
+          # https://github.com/orgs/community/discussions/27028
+          token: ${{ secrets.GH_PERSONAL_TOKEN }}
+      - name: Create tag and push to repo
+        run: |
+          git config --global user.email "flaviostutz@gmail.com"
+          git config --global user.name "Flávio Stutz"
+          npx -y monotag@1.10.0 tag-push --prerelease

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -101,7 +101,7 @@ describe('when using cli', () => {
       '--separator=/v',
     ]);
     expect(exitCode).toBe(0);
-    expect(stdout).toEqual('No changes detected');
+    expect(stdout).toEqual('');
 
     stdout = '';
     exitCode = await run(['', '', 'notes', `--repo-dir=${repoDir}`, '--fromRef=HEAD~3']);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,12 +91,12 @@ const execAction = async (action: string, opts: NextTagOptions, yargs2: Argv): P
 
   // CURRENT ACTION
   if (action === 'current') {
-    const latestTag = await lastTagForPrefix(
-      opts.repoDir,
-      opts.tagPrefix,
-      opts.tagSuffix,
-      opts.verbose,
-    );
+    const latestTag = await lastTagForPrefix({
+      repoDir: opts.repoDir,
+      tagPrefix: opts.tagPrefix,
+      tagSuffix: opts.tagSuffix,
+      verbose: opts.verbose,
+  });
     if (!latestTag) {
       console.log(`No tag found for prefix '${opts.tagPrefix}'`);
       return 1;
@@ -120,12 +120,12 @@ const execAction = async (action: string, opts: NextTagOptions, yargs2: Argv): P
 
   // LATEST ACTION
   if (action === 'latest') {
-    const latestTag = await lastTagForPrefix(
-      opts.repoDir,
-      opts.tagPrefix,
-      opts.tagSuffix,
-      opts.verbose,
-    );
+    const latestTag = await lastTagForPrefix({
+      repoDir: opts.repoDir,
+      tagPrefix: opts.tagPrefix,
+      tagSuffix:opts.tagSuffix,
+      verbose: opts.verbose,
+  });
     if (!latestTag) {
       console.log(`No tag found for prefix '${opts.tagPrefix}'`);
       return 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,7 +96,7 @@ const execAction = async (action: string, opts: NextTagOptions, yargs2: Argv): P
       tagPrefix: opts.tagPrefix,
       tagSuffix: opts.tagSuffix,
       verbose: opts.verbose,
-  });
+    });
     if (!latestTag) {
       console.log(`No tag found for prefix '${opts.tagPrefix}'`);
       return 1;
@@ -123,9 +123,9 @@ const execAction = async (action: string, opts: NextTagOptions, yargs2: Argv): P
     const latestTag = await lastTagForPrefix({
       repoDir: opts.repoDir,
       tagPrefix: opts.tagPrefix,
-      tagSuffix:opts.tagSuffix,
+      tagSuffix: opts.tagSuffix,
       verbose: opts.verbose,
-  });
+    });
     if (!latestTag) {
       console.log(`No tag found for prefix '${opts.tagPrefix}'`);
       return 1;
@@ -144,11 +144,7 @@ const execAction = async (action: string, opts: NextTagOptions, yargs2: Argv): P
       console.log('No changes detected and no previous tag found');
       return 4;
     }
-    if (nt.releaseNotes) {
-      console.log(nt.releaseNotes);
-    } else {
-      console.log('No changes detected');
-    }
+    console.log(nt.releaseNotes);
     saveResultsToFiles(nt, opts);
     return 0;
   }
@@ -183,6 +179,17 @@ const execAction = async (action: string, opts: NextTagOptions, yargs2: Argv): P
     }
 
     if (action === 'tag-git' || action === 'tag-push') {
+      if (nt.existingTag) {
+        console.log('Tag already exists in repo');
+        return 0;
+      }
+
+      if (opts.changelogFile) {
+        console.log('Commiting changelog file');
+        execCmd(opts.repoDir, `git add ${opts.changelogFile}`, opts.verbose);
+        execCmd(opts.repoDir, `git commit -m "chore(release): ${nt.tagName}"`, opts.verbose);
+      }
+
       console.log(`Creating tag ${nt.tagName}`);
 
       if (!nt.releaseNotes) {
@@ -199,7 +206,7 @@ const execAction = async (action: string, opts: NextTagOptions, yargs2: Argv): P
       fs.rmSync(tmpDir, { recursive: true });
       console.log('Tag created successfully');
 
-      if (action === 'tag-push') {
+      if (action === 'tag-push' && !nt.existingTag) {
         console.log("Pushing tag to remote 'origin'");
         execCmd(opts.repoDir, `git push origin ${nt.tagName}`, opts.verbose);
         console.log('Tag pushed to origin successfully');

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -11,33 +11,39 @@ describe('when using git', () => {
   it('should get latest tag for prefix1', async () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     console.log = (): void => {};
-    const ltag = await lastTagForPrefix(repoDir, 'prefix1/', '', true);
+    const ltag = await lastTagForPrefix({ repoDir, tagPrefix: 'prefix1/' });
     expect(ltag).toBe('prefix1/3.4.5-alpha');
+  });
+  it('should get the 2nd latest tag for prefix1', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    console.log = (): void => {};
+    const ltag = await lastTagForPrefix({ repoDir, tagPrefix: 'prefix1/', nth: 1 });
+    expect(ltag).toBe('prefix1/3.3.5');
   });
   it('should get latest tag for prefix1 -', async () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     console.log = (): void => {};
-    const ltag = await lastTagForPrefix(repoDir, 'prefix9-', '', true);
+    const ltag = await lastTagForPrefix({ repoDir, tagPrefix: 'prefix9-' });
     expect(ltag).toBe('prefix9-1.0.1');
   });
   it('should get latest tag for prefix2', async () => {
-    const ltag = await lastTagForPrefix(repoDir, 'prefix2/');
+    const ltag = await lastTagForPrefix({ repoDir, tagPrefix: 'prefix2/' });
     expect(ltag).toBe('prefix2/20.10.0');
   });
   it('should get latest tag for prefix9/v', async () => {
-    const ltag = await lastTagForPrefix(repoDir, 'prefix9/v');
+    const ltag = await lastTagForPrefix({ repoDir, tagPrefix: 'prefix9/v' });
     expect(ltag).toBe('prefix9/v1.0.3');
   });
   it('should return null if no tag found', async () => {
-    const ltag = await lastTagForPrefix(repoDir, 'pref');
+    const ltag = await lastTagForPrefix({ repoDir, tagPrefix: 'pref' });
     expect(ltag).toBeUndefined();
   });
   it('should return null if no tag found for prefix99', async () => {
-    const ltag = await lastTagForPrefix(repoDir, 'prefix99/');
+    const ltag = await lastTagForPrefix({ repoDir, tagPrefix: 'prefix99/' });
     expect(ltag).toBeUndefined();
   });
   it('should get latest tag for empty prefix', async () => {
-    const ltag = await lastTagForPrefix(repoDir, '');
+    const ltag = await lastTagForPrefix({ repoDir, tagPrefix: '' });
     expect(ltag).toEqual('345.2123.143');
   });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -218,7 +218,7 @@ const summarizeCommits = (commits: Commit[]): CommitsSummary => {
 
     // references
     for (const reference of convLog.references) {
-      summary.references.push(`${reference.action} ${reference.raw}`);
+      summary.references.push(`${reference.action ?? ''} ${reference.raw ?? ''}`.trim());
     }
 
     return summary;

--- a/src/notes.test.ts
+++ b/src/notes.test.ts
@@ -17,6 +17,7 @@ describe('when creating release notes notes', () => {
     const nt = await releaseNotes(
       {
         repoDir,
+        tagPrefix: '',
         fromRef: 'HEAD~3',
         toRef: 'HEAD',
         path: 'prefix2',

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -1,15 +1,16 @@
 /* eslint-disable functional/no-let */
 import { filterCommits, summarizeCommits } from './git';
-import { BasicOptions } from './types/BasicOptions';
 import { CommitsSummary } from './types/CommitsSummary';
+import { NextTagOptions } from './types/NextTagOptions';
 import { getDateFromCommit } from './utils/getDateFromCommit';
+import { tagParts } from './utils/tagParts';
 
 /**
  * Filters commits according to opts and creates a formatted string with release notes
  * @param {BasicOptions} opts parameters for getting commits and creating the release notes
  * @returns {string} Release notes
  */
-const releaseNotes = async (opts: BasicOptions, tagName: string): Promise<string> => {
+const releaseNotes = async (opts: NextTagOptions, tagName: string): Promise<string> => {
   if (!opts.fromRef || opts.fromRef === 'auto') {
     throw new Error("'fromRef' is required");
   }
@@ -25,75 +26,82 @@ const releaseNotes = async (opts: BasicOptions, tagName: string): Promise<string
   const commitsSummary = summarizeCommits(commits);
   const versionDate = getDateFromCommit(commits[0].date);
 
-  const rn = formatReleaseNotes(commitsSummary, tagName, versionDate, opts.onlyConvCommit);
+  const rn = formatReleaseNotes({
+    commitsSummary,
+    tagName,
+    versionDate,
+    onlyConvCommit: opts.onlyConvCommit,
+  });
   return rn;
 };
 
-const formatReleaseNotes = (
-  commitsSummary: CommitsSummary,
-  tagName: string,
-  versionDate: string,
-  onlyConvCommit?: boolean,
-): string => {
+const formatReleaseNotes = (args: {
+  commitsSummary: CommitsSummary;
+  tagName: string;
+  versionDate: string;
+  onlyConvCommit?: boolean;
+}): string => {
   let notes = '';
 
-  if (tagName) {
-    notes += `## ${tagName} (${versionDate})\n\n`;
+  const tparts = tagParts(args.tagName);
+
+  if (tparts) {
+    notes += `## ${tparts[1]} (${args.versionDate})\n\n`;
   }
 
   // features
-  if (commitsSummary.features.length > 0) {
+  if (args.commitsSummary.features.length > 0) {
     notes += '### Features\n\n';
-    notes = commitsSummary.features.reduce((pv, feat) => {
+    notes = args.commitsSummary.features.reduce((pv, feat) => {
       return `${pv}* ${feat}\n`;
     }, notes);
     notes += '\n';
   }
 
   // fixes
-  if (commitsSummary.fixes.length > 0) {
+  if (args.commitsSummary.fixes.length > 0) {
     notes += '### Bug Fixes\n\n';
-    notes = commitsSummary.fixes.reduce((pv, fix) => {
+    notes = args.commitsSummary.fixes.reduce((pv, fix) => {
       return `${pv}* ${fix}\n`;
     }, notes);
     notes += '\n';
   }
 
   // maintenance
-  if (commitsSummary.maintenance.length > 0) {
+  if (args.commitsSummary.maintenance.length > 0) {
     notes += '### Maintenance\n\n';
-    notes = commitsSummary.maintenance.reduce((pv, maintenance) => {
+    notes = args.commitsSummary.maintenance.reduce((pv, maintenance) => {
       return `${pv}* ${maintenance}\n`;
     }, notes);
     notes += '\n';
   }
 
   // misc (non conventional commits)
-  if (!onlyConvCommit && commitsSummary.nonConventional.length > 0) {
+  if (!args.onlyConvCommit && args.commitsSummary.nonConventional.length > 0) {
     notes += '### Misc\n\n';
-    notes = commitsSummary.nonConventional.reduce((pv, nonConventional) => {
+    notes = args.commitsSummary.nonConventional.reduce((pv, nonConventional) => {
       return `${pv}* ${nonConventional}\n`;
     }, notes);
     notes += '\n';
   }
 
   // notes
-  if (commitsSummary.notes.length > 0) {
+  if (args.commitsSummary.notes.length > 0) {
     notes += '### Notes\n\n';
-    notes = commitsSummary.notes.reduce((pv, cnotes) => {
+    notes = args.commitsSummary.notes.reduce((pv, cnotes) => {
       return `${pv}* ${cnotes}\n`;
     }, notes);
     notes += '\n';
   }
 
-  if (commitsSummary.references.length > 0 || commitsSummary.authors.length > 0) {
+  if (args.commitsSummary.references.length > 0 || args.commitsSummary.authors.length > 0) {
     notes += '### Info\n\n';
   }
 
   // references
-  if (commitsSummary.references.length > 0) {
+  if (args.commitsSummary.references.length > 0) {
     // remove duplicate references
-    const references = commitsSummary.references.filter((value, index, self) => {
+    const references = args.commitsSummary.references.filter((value, index, self) => {
       return self.indexOf(value) === index;
     });
     notes += `* Refs: ${JSON.stringify(references)
@@ -105,9 +113,9 @@ const formatReleaseNotes = (
   }
 
   // authors
-  if (commitsSummary.authors.length > 0) {
+  if (args.commitsSummary.authors.length > 0) {
     // remove duplicate authors
-    const authors = commitsSummary.authors.filter((value, index, self) => {
+    const authors = args.commitsSummary.authors.filter((value, index, self) => {
       return self.indexOf(value) === index;
     });
     notes += `* Authors: ${JSON.stringify(authors)

--- a/src/tag.test.ts
+++ b/src/tag.test.ts
@@ -51,6 +51,7 @@ describe('when generating next tag with notes', () => {
     });
     if (!nt) throw new Error('Shouldnt be null');
     console.log(nt.releaseNotes);
+    expect(nt.existingTag).toBeFalsy();
     expect(nt.tagName).toBe('prefix1/3.5.0');
     expect(nt.releaseNotes?.includes('## Features')).toBeTruthy();
     expect(
@@ -81,6 +82,7 @@ describe('when generating next tag with notes', () => {
       tagSuffix: '',
     });
     if (!nt) throw new Error('Shouldnt be null');
+    expect(nt.existingTag).toBeTruthy();
     expect(nt.tagName).toBe('prefix9/v1.0.3');
   });
   it('should return next version with suffix', async () => {
@@ -113,6 +115,7 @@ describe('when generating next tag with notes', () => {
     const day = now.getDate();
     const versionDate = `${year}-${month < 10 ? '0' : ''}${month}-${day < 10 ? '0' : ''}${day}`;
 
+    expect(nt.existingTag).toBeFalsy();
     expect(nt.releaseNotes?.trim()).toBe(`## prefix2/21.0.0 (${versionDate})
 
 ### Features
@@ -140,12 +143,15 @@ describe('when generating next tag with notes', () => {
       toRef: 'HEAD',
       path: 'prefix3',
       tagPrefix: 'prefix3/',
+      tagSuffix: '-alpha',
     });
     if (!nt) throw new Error('Shoulnt be null');
     expect(nt.tagName).toBe('prefix3/1.0.0-alpha');
-    expect(nt.releaseNotes).toBeUndefined();
+    expect(nt.existingTag).toBeTruthy();
+    expect(nt.releaseNotes).toContain('## prefix3/1.0.0');
+    expect(nt.releaseNotes).toContain('* test: 88 prefix3 adding test1 file');
   });
-  it('should return latest tag version with new prefix if no new commits found after latest tag in path', async () => {
+  it('should return latest tag version with new suffix if no new commits found after latest tag in path', async () => {
     const nt = await nextTag({
       repoDir,
       fromRef: 'auto',
@@ -154,9 +160,11 @@ describe('when generating next tag with notes', () => {
       tagPrefix: 'prefix3/',
       tagSuffix: '-rc1.0-all',
     });
-    if (!nt) throw new Error('Shoulnt be null');
+    if (!nt) throw new Error('Shouldnt be null');
     expect(nt.tagName).toBe('prefix3/1.0.0-rc1.0-all');
-    expect(nt.releaseNotes).toBeUndefined();
+    expect(nt.existingTag).toBeFalsy();
+    expect(nt.releaseNotes).toContain('## prefix3/1.0.0 (');
+    expect(nt.releaseNotes).toContain('* test: 88 prefix3 adding test1 file');
   });
 
   it('should return zero commits for inexisting path', async () => {

--- a/src/types/TagNotes.ts
+++ b/src/types/TagNotes.ts
@@ -1,6 +1,7 @@
 export type TagNotes = {
   tagName: string;
   version: string;
-  releaseNotes?: string;
+  releaseNotes: string;
   changesDetected: number;
+  existingTag: boolean;
 };

--- a/src/utils/appendChangelog.test.ts
+++ b/src/utils/appendChangelog.test.ts
@@ -9,6 +9,7 @@ import { appendChangelog } from './appendChangelog';
 
 describe('appendChangelog', () => {
   const tag1: TagNotes = {
+    existingTag: false,
     tagName: 'v1.0.0',
     releaseNotes: `## v1.0.0 (2015-01-01)
     
@@ -20,6 +21,7 @@ describe('appendChangelog', () => {
   };
 
   const tag2: TagNotes = {
+    existingTag: false,
     tagName: 'v1.1.0',
     releaseNotes: `## v1.1.0 (2015-01-02)
     
@@ -31,6 +33,7 @@ describe('appendChangelog', () => {
   };
 
   const tag3: TagNotes = {
+    existingTag: false,
     tagName: 'v1.2.0',
     releaseNotes: `## v1.2.0 (2015-01-03)
     
@@ -102,8 +105,4 @@ ${tag1.releaseNotes}
 
 `);
   });
-
-  it('should not append release notes if they already exist in the changelog file', () => {});
-
-  it('should throw an error if release notes are not provided', () => {});
 });

--- a/src/utils/incrementTag.test.ts
+++ b/src/utils/incrementTag.test.ts
@@ -8,12 +8,14 @@ describe('when using tag incrementer', () => {
     let rr = incrementTag({
       fullTagName: 'my-service-prefix/0.1.0-beta+build999',
       type: SemverLevel.MAJOR,
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/1.0.0');
     rr = incrementTag({
       fullTagName: 'my-service-prefix/14.22.5-beta+build999',
       type: SemverLevel.MAJOR,
       tagSuffix: '-beta',
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/15.0.0-beta');
     rr = incrementTag({
@@ -28,12 +30,14 @@ describe('when using tag incrementer', () => {
     let rr = incrementTag({
       fullTagName: 'my-service-prefix-0.1.0-beta+build999',
       type: SemverLevel.MAJOR,
+      tagPrefix: 'my-service-prefix-',
     });
     expect(rr).toBe('my-service-prefix-1.0.0');
     rr = incrementTag({
       fullTagName: 'my-service-prefix-14.22.5-beta+build999',
       type: SemverLevel.MAJOR,
       tagSuffix: '-beta',
+      tagPrefix: 'my-service-prefix-',
     });
     expect(rr).toBe('my-service-prefix-15.0.0-beta');
     rr = incrementTag({
@@ -48,12 +52,14 @@ describe('when using tag incrementer', () => {
     let rr = incrementTag({
       fullTagName: 'my-service-prefix/0.1.0-beta+build999',
       type: SemverLevel.MINOR,
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/0.1.0');
     rr = incrementTag({
       fullTagName: 'my-service-prefix/14.22.5-beta+build999',
       type: SemverLevel.MINOR,
       tagSuffix: '-beta',
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/14.23.0-beta');
     rr = incrementTag({
@@ -68,12 +74,14 @@ describe('when using tag incrementer', () => {
     let rr = incrementTag({
       fullTagName: 'my-service-prefix/0.1.0-beta+build999',
       type: SemverLevel.PATCH,
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/0.1.0');
     rr = incrementTag({
       fullTagName: 'my-service-prefix/14.22.5-beta+build999',
       type: SemverLevel.PATCH,
       tagSuffix: '-beta',
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/14.22.5-beta');
     rr = incrementTag({ fullTagName: '24.22.5-beta+build999', type: SemverLevel.PATCH });
@@ -83,12 +91,14 @@ describe('when using tag incrementer', () => {
     let rr = incrementTag({
       fullTagName: 'my-service-prefix-0.1.0-beta+build999',
       type: SemverLevel.PATCH,
+      tagPrefix: 'my-service-prefix-',
     });
     expect(rr).toBe('my-service-prefix-0.1.0');
     rr = incrementTag({
       fullTagName: 'my-service-prefix-14.22.5-beta+build999',
       type: SemverLevel.PATCH,
       tagSuffix: '-win64',
+      tagPrefix: 'my-service-prefix-',
     });
     expect(rr).toBe('my-service-prefix-14.22.5-win64');
     rr = incrementTag({
@@ -103,6 +113,7 @@ describe('when using tag incrementer', () => {
       fullTagName: 'my-service-prefix/0.1.0-beta+build999',
       type: SemverLevel.MAJOR,
       tagSuffix: '',
+      tagPrefix: 'my-service-prefix/',
       minVersion: '2.0.0',
     });
     expect(rr).toBe('my-service-prefix/2.0.0');
@@ -119,6 +130,7 @@ describe('when using tag incrementer', () => {
       fullTagName: 'my-service-prefix/14.22.5-abraca+build999',
       type: SemverLevel.MINOR,
       tagSuffix: '-beta',
+      tagPrefix: 'my-service-prefix/',
       maxVersion: '14.23.1',
     });
     expect(rr).toBe('my-service-prefix/14.23.0-beta');
@@ -150,30 +162,35 @@ describe('when using tag incrementer', () => {
       fullTagName: 'my-service-prefix/0.1.0-beta+build999',
       type: SemverLevel.PATCH,
       preRelease: true,
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/0.1.1-beta.0');
     rr = incrementTag({
       fullTagName: 'my-service-prefix/14.22.5',
       type: SemverLevel.MINOR,
       preRelease: true,
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/14.23.0-beta.0');
     rr = incrementTag({
       fullTagName: 'my-service-prefix/0.1.5',
       type: SemverLevel.MAJOR,
       preRelease: true,
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/1.0.0-beta.0');
     rr = incrementTag({
       fullTagName: 'my-service-prefix/0.1.5-beta',
       type: SemverLevel.NONE,
       preRelease: false,
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/0.1.5');
     rr = incrementTag({
       fullTagName: 'my-service-prefix/0.1.5-beta',
       type: SemverLevel.NONE,
       preRelease: false,
+      tagPrefix: 'my-service-prefix/',
     });
     expect(rr).toBe('my-service-prefix/0.1.5');
     rr = incrementTag({ fullTagName: '24.22.5-beta.0', type: SemverLevel.NONE, preRelease: true });

--- a/src/utils/lookForCommitsInPreviousTags.ts
+++ b/src/utils/lookForCommitsInPreviousTags.ts
@@ -43,5 +43,6 @@ export const lookForCommitsInPreviousTags = async (
       break;
     }
   }
+
   return commits;
 };

--- a/src/utils/lookForCommitsInPreviousTags.ts
+++ b/src/utils/lookForCommitsInPreviousTags.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-undefined */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable functional/no-let */
+import { filterCommits, lastTagForPrefix } from '../git';
+import { Commit } from '../types/Commit';
+import { NextTagOptions } from '../types/NextTagOptions';
+
+export const lookForCommitsInPreviousTags = async (
+  opts: NextTagOptions,
+  nth: number,
+): Promise<Commit[]> => {
+  const latestTag =
+    // if nth is 0, it means we want the HEAD commit (without tags)
+    nth === 0
+      ? opts.toRef
+      : await lastTagForPrefix({
+          repoDir: opts.repoDir,
+          tagPrefix: opts.tagPrefix,
+          tagSuffix: opts.tagSuffix,
+          verbose: opts.verbose,
+        });
+
+  // go back in history to find a previous tag that actually
+  // has commits with the latest
+  // sometimes multiple tags are applied to the same commitid (e.g: 1.0.0-beta and 1.0.0)
+  let commits: Commit[] = [];
+  for (let i = nth; i < 10; i += 1) {
+    const previousTag = await lastTagForPrefix({
+      repoDir: opts.repoDir,
+      tagPrefix: opts.tagPrefix,
+      tagSuffix: opts.tagSuffix,
+      verbose: opts.verbose,
+      nth: i,
+    });
+
+    commits = await filterCommits({
+      ...opts,
+      fromRef: previousTag,
+      toRef: latestTag,
+    });
+
+    if (commits.length > 0) {
+      break;
+    }
+  }
+  return commits;
+};

--- a/src/utils/notesForLatestTag.test.ts
+++ b/src/utils/notesForLatestTag.test.ts
@@ -1,0 +1,19 @@
+import { createSampleRepo } from './createSampleRepo';
+import { notesForLatestTag } from './notesForLatestTag';
+
+describe('re-generate notes from latest tag', () => {
+  const repoDir = './testcases/notes-latest-tag-repo';
+  beforeAll(async () => {
+    await createSampleRepo(repoDir);
+  });
+  it('should generate notes for existing tag', async () => {
+    const nt = await notesForLatestTag({
+      repoDir,
+      tagPrefix: 'prefix2/',
+      path: 'prefix2',
+    });
+    if (!nt) throw new Error('Shouldnt be undefined');
+    expect(nt).toContain('## prefix2/20.10.0 (2025-02-05)');
+    expect(nt).toContain('* 8 prefix2 creating test3 file');
+  });
+});

--- a/src/utils/notesForLatestTag.ts
+++ b/src/utils/notesForLatestTag.ts
@@ -1,0 +1,42 @@
+/* eslint-disable no-undefined */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable functional/no-let */
+import { lastTagForPrefix, summarizeCommits } from '../git';
+import { formatReleaseNotes } from '../notes';
+import { NextTagOptions } from '../types/NextTagOptions';
+
+import { getDateFromCommit } from './getDateFromCommit';
+import { lookForCommitsInPreviousTags } from './lookForCommitsInPreviousTags';
+
+export const notesForLatestTag = async (opts: NextTagOptions): Promise<string | undefined> => {
+  const latestTag = await lastTagForPrefix({
+    repoDir: opts.repoDir,
+    tagPrefix: opts.tagPrefix,
+    tagSuffix: opts.tagSuffix,
+    verbose: opts.verbose,
+  });
+
+  if (!latestTag) {
+    return undefined;
+  }
+
+  // look for a previous tag that actually has commits
+  // to compose the release notes
+  const commits = await lookForCommitsInPreviousTags(opts, 1);
+  if (commits.length === 0) {
+    return undefined;
+  }
+
+  const commitsSummary = summarizeCommits(commits);
+
+  const versionDate = getDateFromCommit(commits[0].date);
+
+  const releaseNotes = formatReleaseNotes({
+    commitsSummary,
+    tagName: latestTag,
+    versionDate,
+    onlyConvCommit: opts.onlyConvCommit,
+  });
+
+  return releaseNotes;
+};

--- a/src/utils/saveResultsToFiles.test.ts
+++ b/src/utils/saveResultsToFiles.test.ts
@@ -13,6 +13,7 @@ describe('saveResultsToFile', () => {
     version: '1.0.0',
     releaseNotes: 'Initial release',
     changesDetected: 1,
+    existingTag: false,
   };
 
   const releaseOptions: NextTagOptions = {

--- a/src/utils/saveResultsToFiles.ts
+++ b/src/utils/saveResultsToFiles.ts
@@ -44,7 +44,7 @@ export const saveResultsToFiles = (nt: TagNotes, opts: NextTagOptions): void => 
   }
 
   // save changelog to file
-  if (!opts.preRelease && opts.changelogFile) {
+  if (opts.changelogFile) {
     appendChangelog(opts.changelogFile, nt);
   }
 };


### PR DESCRIPTION
## Summary

Now when using "tag" or "notes" command, even if the tag is not new, the release notes will be rebuilt as if it was the first time creating it for idempontency