### PR TITLE
feat: support multiple paths in analysis

### DIFF
--- a/.github/workflows/create-release-pre.yml
+++ b/.github/workflows/create-release-pre.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.GH_PERSONAL_TOKEN }}
       - name: Create tag and push to repo
         run: |
-          npx -y monotag@1.20.0 tag-push \
+          npx -y monotag@1.21.0 tag-push \
             -v \
             --git-username="Flávio Stutz" \
             --git-email="flaviostutz@gmail.com" \

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.GH_PERSONAL_TOKEN }}
       - name: Create tag and push to repo
         run: |
-          npx -y monotag@1.20.0 tag-push \
+          npx -y monotag@1.21.0 tag-push \
             -v \
             --git-username="Flávio Stutz" \
             --git-email="flaviostutz@gmail.com" \

--- a/README.md
+++ b/README.md
@@ -129,10 +129,11 @@ Options:
   -v, --verbose                       Run with verbose logging
                                                       [boolean] [default: false]
   -d, --path                          File path inside repo to consider when
-                                      analysing changes. Commits that don't
-                                      touch files in this path will be ignored.
-                                      Defaults to current dir.
-                                                      [string] [default: "auto"]
+                                      analysing changes. Can be a list separated
+                                      by ','. Commits that don't touch files in
+                                      this path will be ignored. Defaults to
+                                      current dir. E.g.:
+                                      services/service1,shared/libs                                                      [string] [default: "auto"]
   -f, --from-ref                      Starting point ref for analysing changes
                                       in commits. Defaults to auto, which will
                                       be last version with this same tag prefix

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,7 +4,7 @@
 import * as fs from 'node:fs';
 import { randomBytes } from 'node:crypto';
 
-import { run } from './cli';
+import { expandPathWithDefaults, run } from './cli';
 import { createSampleRepo } from './utils/tests';
 import { execCmd } from './utils/os';
 
@@ -150,10 +150,14 @@ describe('when using cli', () => {
     expect(stdout).toMatch(/^346\.0\.0/);
     expect(exitCode).toBe(0);
 
-    // get next version
+    // get next tag for multiple path sources
     stdout = '';
-    exitCode = await run(['', '', 'tag', `--repo-dir=${repoDir}`]);
-    expect(stdout).toMatch('346.0.0346.0.0## 346.0.0');
+    exitCode = await run(['', '', 'tag', `--repo-dir=${repoDir}`, '--paths=prefix1,prefix3']);
+    expect(stdout).toMatch('VVV');
+    // parei aqui... auto tag should be prefix1
+    expect(stdout).toMatch('1 prefix1 adding test1');
+    expect(stdout).toMatch('test: 88 prefix3 adding test1 ');
+    expect(stdout).not.toMatch('chore: 13 prefix2 updating');
     expect(exitCode).toBe(0);
 
     // get next tag as prerelease
@@ -310,5 +314,35 @@ describe('when using cli', () => {
       await run(['', '', 'tag-push', `--repo-dir=${repoDir}`, '--fromRef=HEAD~5']);
     };
     await expect(rr1).rejects.toThrow();
+  });
+});
+
+describe('expandPathWithDefaults', () => {
+  it('should detect relative current dir when path is auto', () => {
+    const repo = '/repo';
+    const current = '/repo/services/app';
+    const result = expandPathWithDefaults(['auto'], repo, current);
+    expect(result).toEqual(['services/app']);
+  });
+
+  it('should return empty if current dir is outside repo', () => {
+    const repo = '/repo';
+    const current = '/other/app';
+    const result = expandPathWithDefaults(['auto'], repo, current);
+    expect(result).toEqual(['']);
+  });
+
+  it('should handle relative paths', () => {
+    const repo = '/repo';
+    const current = '/repo/src';
+    const result = expandPathWithDefaults(['../test'], repo, current);
+    expect(result).toEqual(['test']);
+  });
+
+  it('should handle relative paths multiple', () => {
+    const repo = '/repo';
+    const current = '/repo/src';
+    const result = expandPathWithDefaults(['../test', '..'], repo, current);
+    expect(result).toEqual(['test', '']);
   });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -152,10 +152,10 @@ describe('when using cli', () => {
 
     // get next tag for multiple path sources
     stdout = '';
-    exitCode = await run(['', '', 'tag', `--repo-dir=${repoDir}`, '--paths=prefix1,prefix3']);
-    expect(stdout).toMatch('VVV');
-    // parei aqui... auto tag should be prefix1
-    expect(stdout).toMatch('1 prefix1 adding test1');
+    exitCode = await run(['', '', 'tag', `--repo-dir=${repoDir}`, '--path=prefix1,prefix3']);
+    expect(stdout).not.toMatch(/^346\.0\.0/); // should prefix tag with "prefix1"
+    expect(stdout).toMatch(/^prefix1\//); // should prefix tag with "prefix1"
+    expect(stdout).toMatch('9 prefix1 updating test1 and test2 files again for module prefix1');
     expect(stdout).toMatch('test: 88 prefix3 adding test1 ');
     expect(stdout).not.toMatch('chore: 13 prefix2 updating');
     expect(exitCode).toBe(0);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -367,7 +367,7 @@ const addOptions = (y: Argv, saveToFile?: boolean): any => {
       alias: 'p',
       type: 'string',
       describe:
-        'Tag prefix to look for latest versions and to use on generated tags. If not defined will be derived from last path part',
+        'Tag prefix to look for latest versions and to use on generated tags. If not defined will be derived from last path part (of the first path defined)',
       default: 'auto',
     })
     .option('separator', {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -240,41 +240,18 @@ const expandDefaults = (args: any): CliNextTagOptions => {
   const absRepoDir = execCmd(repoDir, 'git rev-parse --show-toplevel', verbose).trim();
 
   // detect current dir reference to repo
-  let pathRepo = <string>args.path;
+  const pathRepoList = defaultValueListString(<string>args.path, ['auto']);
+  if (!pathRepoList) throw new Error('path must be defined');
 
-  // automatically detect path inside repo dir according to current dir
-  if (!pathRepo || pathRepo === 'auto') {
-    const currentDir = process.cwd();
-    if (currentDir.includes(absRepoDir)) {
-      pathRepo = currentDir.replace(absRepoDir, '');
-    } else {
-      // defaults to repo root
-      pathRepo = '';
-    }
-
-    // support relative paths to current dir
-  } else if (pathRepo.startsWith('..')) {
-    const absPathRepo = path.resolve(process.cwd(), pathRepo);
-    if (absPathRepo.includes(absRepoDir)) {
-      pathRepo = absPathRepo.replace(absRepoDir, '');
-    } else {
-      throw new Error(`Path "${pathRepo}" is not inside repo dir "${absRepoDir}"`);
-    }
-  }
-
-  // path is relative to repo dir
-  // support paths starting with /
-  if (pathRepo.startsWith('/')) {
-    pathRepo = pathRepo.slice(1);
-  }
-
-  if (args.verbose) {
-    console.log(`Analysing changes in path "${absRepoDir}/${pathRepo}"`);
+  const pathsRepo = expandPathWithDefaults(pathRepoList, absRepoDir, process.cwd());
+  if (verbose) {
+    console.log(`Repo dir is "${absRepoDir}"`);
+    console.log(`Analysing changes in "${pathsRepo.join(',')}"`);
   }
 
   const basicOpts: BasicOptions = {
     repoDir: absRepoDir,
-    path: pathRepo,
+    paths: pathsRepo,
     fromRef: <string>args['from-ref'],
     toRef: <string>args['to-ref'],
     onlyConvCommit: defaultValueBoolean(args['conv-commit'], true),
@@ -296,7 +273,8 @@ const expandDefaults = (args: any): CliNextTagOptions => {
 
   // default tag prefix is relative to path inside repo
   if (tagPrefix === 'auto') {
-    tagPrefix = lastPathPart(basicOpts.path);
+    // use first path as tag prefix
+    tagPrefix = lastPathPart(basicOpts.paths.length > 0 ? basicOpts.paths[0] : '');
     if (tagPrefix.length > 0) {
       tagPrefix += args.separator;
     }
@@ -350,7 +328,7 @@ const addOptions = (y: Argv, saveToFile?: boolean): any => {
       alias: 'd',
       type: 'string',
       describe:
-        "File path inside repo to consider when analysing changes. Commits that don't touch files in this path will be ignored. Defaults to current dir.",
+        "File path inside repo to consider when analysing changes. Can be a list separated by ','. Commits that don't touch files in this path will be ignored. Defaults to current dir. E.g.: services/service1,shared/libs",
       default: 'auto',
     })
     .option('from-ref', {
@@ -548,6 +526,43 @@ const lastPathPart = (fullpath: string): string => {
     return fullpath;
   }
   return part;
+};
+
+export const expandPathWithDefaults = (
+  paths: string[],
+  absRepoDir: string,
+  currentDir: string,
+): string[] => {
+  const dpaths = paths.map((p: string) => {
+    let pathRepo = p;
+
+    // automatically detect path inside repo dir according to current dir
+    if (!pathRepo || pathRepo === 'auto') {
+      if (currentDir.includes(absRepoDir)) {
+        pathRepo = currentDir.replace(absRepoDir, '');
+      } else {
+        // defaults to repo root
+        pathRepo = '';
+      }
+
+      // support relative paths to current dir
+    } else if (pathRepo.startsWith('..')) {
+      const absPathRepo = path.resolve(currentDir, pathRepo);
+      if (absPathRepo.includes(absRepoDir)) {
+        pathRepo = absPathRepo.replace(absRepoDir, '');
+      } else {
+        throw new Error(`Path "${pathRepo}" is not inside repo dir "${absRepoDir}"`);
+      }
+    }
+
+    // path is relative to repo dir
+    // support paths starting with /
+    if (pathRepo.startsWith('/')) {
+      pathRepo = pathRepo.slice(1);
+    }
+    return pathRepo;
+  });
+  return dpaths;
 };
 
 export { run };

--- a/src/files.test.ts
+++ b/src/files.test.ts
@@ -23,7 +23,7 @@ describe('saveResultsToFile', () => {
     repoDir,
     tagPrefix: 'v',
     verbose: false,
-    path: '.',
+    paths: ['.'],
     versionFile: 'dist/version.txt',
     notesFile: 'dist/changelog.md',
     tagFile: 'dist/releasetag.txt',
@@ -44,7 +44,7 @@ describe('saveResultsToFile', () => {
 
   it('should save version to file with custom opts', () => {
     saveResultsToFiles(tagNotes, {
-      path: '.',
+      paths: ['.'],
       repoDir,
       tagPrefix: 'v',
       versionFile: `${repoDir}/dist/versionAA.txt`,

--- a/src/git.ts
+++ b/src/git.ts
@@ -31,8 +31,6 @@ export const findCommitsTouchingPath = async (opts: BasicOptions): Promise<Commi
     refs = `${opts.fromRef}...${opts.toRef}`;
   }
 
-  // const refs = `${opts.fromRef ?? ''} ${opts.toRef}`;
-
   execCmd(opts.repoDir, `git --version`, opts.verbose);
 
   // execute just to test if refs are valid
@@ -72,9 +70,19 @@ export const findCommitsTouchingPath = async (opts: BasicOptions): Promise<Commi
       if (!cm) {
         return false;
       }
-      // only keep commits that have touched any file inside "path"
+      // only keep commits that have touched any file inside any of the paths provided to be analised
       return cm.files.some((fn: string): boolean => {
-        return fn.startsWith(opts.path);
+        if (!opts.paths || opts.paths.length === 0) {
+          return true;
+        }
+        // check if this file is inside any of the paths
+        return opts.paths.some((p: string): boolean => {
+          // empty path means any path
+          if (p.trim().length === 0) {
+            return true;
+          }
+          return fn.startsWith(p);
+        });
       });
     })
     .map((cm: Commit | undefined): Commit => {

--- a/src/notes.test.ts
+++ b/src/notes.test.ts
@@ -22,7 +22,7 @@ describe('re-generate notes from latest tag', () => {
     const nt = await notesForLatestTag({
       repoDir,
       tagPrefix: 'prefix2/',
-      path: 'prefix2',
+      paths: ['prefix2'],
     });
     if (!nt) throw new Error('Shouldnt be undefined');
     expect(nt).toContain('## prefix2/20.10.0 (');
@@ -35,7 +35,7 @@ describe('re-generate notes from latest tag', () => {
     const nt = await notesForLatestTag({
       repoDir,
       tagPrefix: '',
-      path: '',
+      paths: [''],
     });
     if (!nt) throw new Error('Shouldnt be undefined');
     expect(nt).toContain('## 345.2123.143 (');
@@ -48,7 +48,7 @@ describe('re-generate notes from latest tag', () => {
     const nt = await notesForLatestTag({
       repoDir,
       tagPrefix: 'SOMETHING_INEXISTENT/',
-      path: 'prefix2',
+      paths: ['prefix2'],
     });
     expect(nt).toBeUndefined();
   });
@@ -57,7 +57,7 @@ describe('re-generate notes from latest tag', () => {
     const nt = await notesForLatestTag({
       repoDir,
       tagPrefix: 'lonelytag/',
-      path: 'INEXISTENT_PATH',
+      paths: ['INEXISTENT_PATH'],
     });
     expect(nt).toBeUndefined();
   });

--- a/src/tag.test.ts
+++ b/src/tag.test.ts
@@ -18,7 +18,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: '',
+      paths: [''],
       tagPrefix: '',
     });
     expect(nt?.releaseNotes).toContain('## 346.0.0 (');
@@ -37,7 +37,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD~16',
-      path: '',
+      paths: [''],
       tagPrefix: '',
     });
     if (!nt) throw new Error('Shouldnt be null');
@@ -48,7 +48,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD~16',
-      path: '',
+      paths: [''],
       tagPrefix: '',
     });
     if (!nt) throw new Error('Shouldnt be null');
@@ -59,7 +59,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'inexistentModule',
+      paths: ['inexistentModule'],
       tagPrefix: 'inexistentModule/',
     });
     expect(nt).toBeUndefined();
@@ -69,7 +69,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'prefix1',
+      paths: ['prefix1'],
       tagPrefix: 'prefix1/',
     });
     if (!nt) throw new Error('Shouldnt be null');
@@ -87,7 +87,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'prefix1',
+      paths: ['prefix1'],
       tagPrefix: 'prefix1/',
       tagSuffix: '-alphaaaaa',
     });
@@ -99,7 +99,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'prefix9',
+      paths: ['prefix9'],
       tagPrefix: 'prefix9/v',
       tagSuffix: '',
     });
@@ -112,7 +112,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'prefix1',
+      paths: ['prefix1'],
       tagPrefix: 'prefix1/',
       tagSuffix: '-beta-gama',
     });
@@ -124,7 +124,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'prefix2',
+      paths: ['prefix2'],
       tagPrefix: 'prefix2/',
       notesDisableLinks: true,
     });
@@ -165,7 +165,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'prefix3',
+      paths: ['prefix3'],
       tagPrefix: 'prefix3/',
       tagSuffix: '-alpha',
     });
@@ -180,7 +180,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'prefix3',
+      paths: ['prefix3'],
       tagPrefix: 'prefix3/',
       tagSuffix: '-rc1.0-all',
     });
@@ -196,7 +196,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'HEAD~9',
       toRef: 'HEAD',
-      path: 'inexistentModule',
+      paths: ['inexistentModule'],
     });
     expect(clogs).toHaveLength(0);
   });
@@ -208,7 +208,7 @@ describe('when generating next tag with notes', () => {
         repoDir,
         fromRef: 'HEAD~9999',
         toRef: 'HEAD',
-        path: '',
+        paths: [''],
       });
     };
     await expect(exec).rejects.toThrow('failed');
@@ -218,7 +218,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'HEAD~16',
       toRef: 'HEAD',
-      path: 'prefix1',
+      paths: ['prefix1'],
     });
     expect(clogs).toHaveLength(7);
     expect(clogs.filter((cl) => cl.message.includes('prefix1'))).toHaveLength(7);
@@ -229,7 +229,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'HEAD~12',
       toRef: 'HEAD',
-      path: 'prefix2',
+      paths: ['prefix2'],
     });
     expect(clogs).toHaveLength(8);
     expect(clogs.filter((cl) => cl.message.includes('prefix2'))).toHaveLength(8);
@@ -240,7 +240,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'HEAD~6',
       toRef: 'HEAD',
-      path: '',
+      paths: [''],
     });
     expect(clogs).toHaveLength(6);
     expect(clogs[0].message.includes('10')).toBeTruthy();
@@ -255,7 +255,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'prefix1',
+      paths: ['prefix1'],
       tagPrefix: 'prefix1/',
       preRelease: true,
     });
@@ -268,7 +268,7 @@ describe('when generating next tag with notes', () => {
       repoDir,
       fromRef: 'auto',
       toRef: 'HEAD',
-      path: 'prefix1',
+      paths: ['prefix1'],
       tagPrefix: 'prefix1/',
       preRelease: false,
     });

--- a/src/tag.test.ts
+++ b/src/tag.test.ts
@@ -276,6 +276,23 @@ describe('when generating next tag with notes', () => {
     expect(nt.tagName).toBe('prefix1/3.5.0');
     expect(nt.version).toBe('3.5.0');
   });
+  it('create tag that touches multiple paths using the first tag in array as tag prefix reference', async () => {
+    const nt = await nextTag({
+      repoDir,
+      fromRef: 'auto',
+      toRef: 'HEAD',
+      paths: ['prefix2', 'prefix1'],
+      tagPrefix: 'p2p1/',
+      preRelease: false,
+    });
+    if (!nt) throw new Error('Shouldnt be null');
+    expect(nt.version).toBe('1.0.0');
+    expect(nt.tagName).toBe('p2p1/1.0.0');
+    expect(nt.releaseNotes).toContain('## p2p1/1.0.0');
+    expect(nt.releaseNotes).toContain('2 prefix1 updating test1 file');
+    expect(nt.releaseNotes).toContain('6 prefix2 updating test1 file');
+    expect(nt.releaseNotes).not.toContain('* test: 88 prefix3 adding test1 file');
+  });
 });
 
 describe('when using tag incrementer', () => {

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -51,7 +51,7 @@ export const nextTag = async (opts: NextTagOptions): Promise<TagNotes | undefine
 
   if (opts.verbose) {
     console.log(
-      `Analysing commit range ${opts.fromRef}...${opts.toRef} and filtering path "${opts.path}"`,
+      `Analysing commit range ${opts.fromRef}...${opts.toRef} and filtering paths "${opts.paths.join(',')}"`,
     );
   }
 

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -11,10 +11,10 @@ export type BasicOptions = {
    */
   repoDir: string;
   /**
-   * Path inside repository for looking for changes
-   * Defaults to any path
+   * Path list inside repository for looking for changes
+   * @default empty which means any changes in repo
    */
-  path: string;
+  paths: string[];
   /**
    * Git ref range (starting point) for searching for changes in git log history
    * @default latest tag


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request: -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

## Summary

Adds support for multiple paths to cli option "path" (multiple paths separated by comma) and api base "paths", that now is an array.

## Breaking changes

None

## Closing issues

#43 